### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   labeler:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       -
         name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/Lilly3252/lilly/security/code-scanning/1](https://github.com/Lilly3252/lilly/security/code-scanning/1)

To fix the issue, add a `permissions` block specifying only the least privileges needed for the job. Since this workflow only uses the GitHub token to run the labeler (which modifies labels on issues and PRs), the necessary permissions are most likely `contents: read` and `issues: write`. You should place the `permissions` block at the job level (inside `labeler`), unless you want it to apply to all jobs—here there is only one. Insert it directly under `runs-on: ubuntu-latest` (before `steps:`) in the `.github/workflows/labels.yml` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
